### PR TITLE
Fix integer overflow in PatchCalcUtil.

### DIFF
--- a/src/utils/PatchCalcUtil.java
+++ b/src/utils/PatchCalcUtil.java
@@ -22,6 +22,7 @@ public class PatchCalcUtil {
     }
 
     public static int getNextIndex(int curIndex, double mutation) {
-        return curIndex + 1 + (int) (Math.log(rand.nextDouble()) / Math.log(1.0 - mutation));
+        // casting the entire result to int correctly processes int overflows.
+        return (int) (curIndex + 1 + Math.log(rand.nextDouble()) / Math.log(1.0 - mutation));
     }
 }


### PR DESCRIPTION
This has no effect on n=10000, but prevents crashes on n=40000 and very small mutation rates.